### PR TITLE
Update dependency lint-staged to v4.3.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -36,7 +36,7 @@
     "flow-typed": "2.2.0",
     "html-webpack-plugin": "2.30.1",
     "husky": "0.14.3",
-    "lint-staged": "4.2.3",
+    "lint-staged": "4.3.0",
     "prettier": "1.7.4",
     "webpack": "3.6.0",
     "webpack-dev-server": "2.9.1"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1143,7 +1143,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.11.x, commander@^2.9.0, commander@~2.11.0:
+commander@2.11.x, commander@^2.11.0, commander@^2.9.0, commander@~2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
@@ -2871,12 +2871,13 @@ leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 
-lint-staged@4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.2.3.tgz#5a1f12256af06110b96225f109dbf215009a37a9"
+lint-staged@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.3.0.tgz#ed0779ad9a42c0dc62bb3244e522870b41125879"
   dependencies:
     app-root-path "^2.0.0"
     chalk "^2.1.0"
+    commander "^2.11.0"
     cosmiconfig "^1.1.0"
     execa "^0.8.0"
     is-glob "^4.0.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://github.com/okonet/lint-staged">lint-staged</a> from <code>v4.2.3</code> to <code>v4.3.0</code></p>
<h3 id="commits">Commits</h3>
<p><details><br />
<summary>okonet/lint-staged</summary></p>
<h4 id="430">4.3.0</h4>
<ul>
<li><a href="https://github.com/okonet/lint-staged/commit/54809ae1837617f7f4e62c72040d62235e73f59f"><code>54809ae</code></a> feat: Allow config to be provided via command-line (#&#8203;304)</li>
<li><a href="https://github.com/okonet/lint-staged/commit/eacb3d2b73bf2a4fd54cc2a0f830a72c9f1a933f"><code>eacb3d2</code></a> chore(package): update consolemock to version 0.3.0 (#&#8203;307)</li>
<li><a href="https://github.com/okonet/lint-staged/commit/50416a94d6e4280b37e8a0d8cdf867910f042af1"><code>50416a9</code></a> test: Change process.env.HOME to os.tmpdir (#&#8203;301)</li>
<li><a href="https://github.com/okonet/lint-staged/commit/213876560b77a62f5b26bfb13ba80e81aa6fd967"><code>2138765</code></a> test: Use os.tmpdir instead of process.env.HOME (#&#8203;300)</li>
<li><a href="https://github.com/okonet/lint-staged/commit/57f1fe32fcab7b455ca586c7fa0a999f6ed7fe6c"><code>57f1fe3</code></a> docs: Add code comment for func findBin&gt;npmArgs (#&#8203;298)</li>
</ul>
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovateapp.com">Renovate Bot</a>.</p>