### PR TITLE
Update dependency webpack-dev-server to v2.9.2

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,6 @@
     "lint-staged": "4.3.0",
     "prettier": "1.7.4",
     "webpack": "3.8.1",
-    "webpack-dev-server": "2.9.1"
+    "webpack-dev-server": "2.9.2"
   }
 }

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5118,9 +5118,9 @@ webpack-dev-middleware@^1.11.0:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
-webpack-dev-server@2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.9.1.tgz#7ac9320b61b00eb65b2109f15c82747fc5b93585"
+webpack-dev-server@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.9.2.tgz#0fbab915701d25a905a60e1e784df19727da800f"
   dependencies:
     ansi-html "0.0.7"
     array-includes "^3.0.3"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://github.com/webpack/webpack-dev-server">webpack-dev-server</a> from <code>v2.9.1</code> to <code>v2.9.2</code></p>
<h3 id="commits">Commits</h3>
<p><details><br />
<summary>webpack/webpack-dev-server</summary></p>
<h4 id="292">2.9.2</h4>
<ul>
<li><a href="https://github.com/webpack/webpack-dev-server/commit/32412bbbabd832ce1f1b6e0c9c8e53bc55875785"><code>32412bb</code></a> 2.9.2</li>
<li><a href="https://github.com/webpack/webpack-dev-server/commit/1af8f0e508e08b4e8f036311ae6c72b77f77600f"><code>1af8f0e</code></a> Remove header property validation (#&#8203;1115)</li>
<li><a href="https://github.com/webpack/webpack-dev-server/commit/c490b245ad65f315762e03e51710f7f7177b1e7b"><code>c490b24</code></a> allow explicitly setting the protocol from the public option (#&#8203;1117)</li>
<li><a href="https://github.com/webpack/webpack-dev-server/commit/ee7231baf9f41082435832e6df3e57f4dafee013"><code>ee7231b</code></a> Changed property descriptor for Array.includes polyfill (#&#8203;1134)</li>
<li><a href="https://github.com/webpack/webpack-dev-server/commit/5a7f26b54081f5ff5a4bbcdd4e0deb131332095e"><code>5a7f26b</code></a> updating readme with support, usage, and caveats</li>
</ul>
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovateapp.com">Renovate Bot</a>.</p>